### PR TITLE
Watch jade files not scoped to app/pages (?)

### DIFF
--- a/config/plugins/jade.coffee
+++ b/config/plugins/jade.coffee
@@ -55,7 +55,7 @@ module.exports = (lineman) ->
 
     watch:
       jadePages:
-        files: "<%= files.jade.pages %>"
+        files: "<%= files.jade.pageRoot %> <%= files.jade.pages %>"
         tasks: ["jade:pagesDev"]
       jadeTemplates:
         files: "<%= files.jade.templates %>"

--- a/config/plugins/jade.coffee
+++ b/config/plugins/jade.coffee
@@ -55,7 +55,7 @@ module.exports = (lineman) ->
 
     watch:
       jadePages:
-        files: "<%= files.jade.pageRoot %> <%= files.jade.pages %>"
+        files: ["<%= files.jade.pageRoot %><%= files.jade.pages %>", "<%= files.jade.templates %>"]
         tasks: ["jade:pagesDev"]
       jadeTemplates:
         files: "<%= files.jade.templates %>"


### PR DESCRIPTION
Hey, it's late and I'm new to github so take a look while keeping this in mind :)

I think the watch for jadePages could be set to only look at .jade files in the "app/page" directory.
