### PR TITLE
Fix overrides and unnecessary lines

### DIFF
--- a/config/plugins/jade.coffee
+++ b/config/plugins/jade.coffee
@@ -8,16 +8,14 @@ module.exports = (lineman) ->
     template:
       jade: "app/templates/**/*.jade"
       generatedJade: "generated/template/jade.js"
-    pages:
-      source: lineman.config.files.pages.source.concat("!<%= files.jade.pageRoot %>/<%= files.jade.pages %>")
 
   config:
     loadNpmTasks: lineman.config.application.loadNpmTasks.concat('grunt-contrib-jade')
 
     prependTasks:
       common: ["jade:templates"].concat(lineman.config.application.prependTasks.common)
-      dev: lineman.config.application.prependTasks.common.concat("jade:pagesDev")
-      dist: lineman.config.application.prependTasks.common.concat("jade:pagesDist")
+      dev: lineman.config.application.prependTasks.dev.concat("jade:pagesDev")
+      dist: lineman.config.application.prependTasks.dist.concat("jade:pagesDist")
 
     jade:
       templates:


### PR DESCRIPTION
- prependTasks overrides are now fixed. (it was overwriting with prependTasks.common for all three!)
- modifying pages.source variable to concatenate <%= files.jade.pages %> is pointless and causes issues. (they're [already](https://github.com/linemanjs/lineman/blob/master/config/files.coffee#L52) well defined to include all files)

The current version of lineman-jade even breaks a new 'vanilla' lineman project (tested on version 0.36.4). Hope this fixes that!
